### PR TITLE
feat: scaffold CivicFire Engine monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "civicfire-engine",
+  "private": true,
+  "workspaces": ["packages/*"]
+}

--- a/packages/game-client/assets/characters/placeholder.txt
+++ b/packages/game-client/assets/characters/placeholder.txt
@@ -1,0 +1,1 @@
+placeholder

--- a/packages/game-client/assets/effects/placeholder.txt
+++ b/packages/game-client/assets/effects/placeholder.txt
@@ -1,0 +1,1 @@
+placeholder

--- a/packages/game-client/assets/tiles/placeholder.txt
+++ b/packages/game-client/assets/tiles/placeholder.txt
@@ -1,0 +1,1 @@
+placeholder

--- a/packages/game-client/index.html
+++ b/packages/game-client/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>CivicFire Engine</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/game-client/package.json
+++ b/packages/game-client/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "game-client",
+  "version": "0.1.0",
+  "type": "module",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@reduxjs/toolkit": "^1.9.5",
+    "react-redux": "^8.1.1",
+    "game-core": "file:../game-core"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "tsc --noEmit"
+  }
+}

--- a/packages/game-client/src/App.tsx
+++ b/packages/game-client/src/App.tsx
@@ -1,0 +1,13 @@
+import GameCanvas from './components/GameCanvas';
+import HUD from './components/HUD';
+import PolicyMenu from './components/PolicyMenu';
+
+export default function App() {
+  return (
+    <div>
+      <GameCanvas />
+      <HUD />
+      <PolicyMenu />
+    </div>
+  );
+}

--- a/packages/game-client/src/components/GameCanvas.tsx
+++ b/packages/game-client/src/components/GameCanvas.tsx
@@ -1,0 +1,18 @@
+import { useRef, useEffect } from 'react';
+
+export default function GameCanvas() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (canvas) {
+      const ctx = canvas.getContext('2d');
+      if (ctx) {
+        ctx.fillStyle = 'black';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+      }
+    }
+  }, []);
+
+  return <canvas ref={canvasRef} width={800} height={600} />;
+}

--- a/packages/game-client/src/components/HUD.tsx
+++ b/packages/game-client/src/components/HUD.tsx
@@ -1,0 +1,14 @@
+import { useSelector } from 'react-redux';
+import { RootState } from '../store';
+
+export default function HUD() {
+  const score = useSelector((state: RootState) => state.combat.score);
+  const credits = useSelector((state: RootState) => state.economy.credits);
+
+  return (
+    <div>
+      <p>Score: {score}</p>
+      <p>Credits: {credits}</p>
+    </div>
+  );
+}

--- a/packages/game-client/src/components/PolicyMenu.tsx
+++ b/packages/game-client/src/components/PolicyMenu.tsx
@@ -1,0 +1,23 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { enactPolicy } from 'game-core';
+import { RootState } from '../store';
+
+export default function PolicyMenu() {
+  const dispatch = useDispatch();
+  const policies = useSelector((state: RootState) => state.policy.enacted);
+
+  const handleEnact = () => {
+    dispatch(enactPolicy('New Policy'));
+  };
+
+  return (
+    <div>
+      <button onClick={handleEnact}>Enact Policy</button>
+      <ul>
+        {policies.map((p, i) => (
+          <li key={i}>{p}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/packages/game-client/src/main.tsx
+++ b/packages/game-client/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
+import { store } from './store';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <Provider store={store}>
+      <App />
+    </Provider>
+  </React.StrictMode>
+);

--- a/packages/game-client/src/store.ts
+++ b/packages/game-client/src/store.ts
@@ -1,0 +1,19 @@
+import { configureStore } from '@reduxjs/toolkit';
+import {
+  combatReducer,
+  economyReducer,
+  factionsReducer,
+  policyReducer
+} from 'game-core';
+
+export const store = configureStore({
+  reducer: {
+    combat: combatReducer,
+    economy: economyReducer,
+    factions: factionsReducer,
+    policy: policyReducer
+  }
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/packages/game-client/tsconfig.json
+++ b/packages/game-client/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}

--- a/packages/game-client/vite.config.ts
+++ b/packages/game-client/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});

--- a/packages/game-core/package.json
+++ b/packages/game-core/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "game-core",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "type": "module",
+  "dependencies": {
+    "@reduxjs/toolkit": "^1.9.5"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "tsc -p tsconfig.json --noEmit"
+  }
+}

--- a/packages/game-core/src/index.ts
+++ b/packages/game-core/src/index.ts
@@ -1,0 +1,5 @@
+export * from './slices/combatSlice';
+export * from './slices/economySlice';
+export * from './slices/factionsSlice';
+export * from './slices/policySlice';
+export * from './simulation';

--- a/packages/game-core/src/simulation.ts
+++ b/packages/game-core/src/simulation.ts
@@ -1,0 +1,9 @@
+export class SimulationEngine {
+  start() {
+    console.log('Simulation started');
+  }
+
+  update(_delta: number) {
+    // TODO: simulation logic
+  }
+}

--- a/packages/game-core/src/slices/combatSlice.ts
+++ b/packages/game-core/src/slices/combatSlice.ts
@@ -1,0 +1,20 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface CombatState {
+  score: number;
+}
+
+const initialState: CombatState = { score: 0 };
+
+const combatSlice = createSlice({
+  name: 'combat',
+  initialState,
+  reducers: {
+    addScore(state, action: PayloadAction<number>) {
+      state.score += action.payload;
+    }
+  }
+});
+
+export const { addScore } = combatSlice.actions;
+export const combatReducer = combatSlice.reducer;

--- a/packages/game-core/src/slices/economySlice.ts
+++ b/packages/game-core/src/slices/economySlice.ts
@@ -1,0 +1,20 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface EconomyState {
+  credits: number;
+}
+
+const initialState: EconomyState = { credits: 0 };
+
+const economySlice = createSlice({
+  name: 'economy',
+  initialState,
+  reducers: {
+    adjustCredits(state, action: PayloadAction<number>) {
+      state.credits += action.payload;
+    }
+  }
+});
+
+export const { adjustCredits } = economySlice.actions;
+export const economyReducer = economySlice.reducer;

--- a/packages/game-core/src/slices/factionsSlice.ts
+++ b/packages/game-core/src/slices/factionsSlice.ts
@@ -1,0 +1,20 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface FactionsState {
+  alignment: string;
+}
+
+const initialState: FactionsState = { alignment: 'neutral' };
+
+const factionsSlice = createSlice({
+  name: 'factions',
+  initialState,
+  reducers: {
+    setAlignment(state, action: PayloadAction<string>) {
+      state.alignment = action.payload;
+    }
+  }
+});
+
+export const { setAlignment } = factionsSlice.actions;
+export const factionsReducer = factionsSlice.reducer;

--- a/packages/game-core/src/slices/policySlice.ts
+++ b/packages/game-core/src/slices/policySlice.ts
@@ -1,0 +1,20 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface PolicyState {
+  enacted: string[];
+}
+
+const initialState: PolicyState = { enacted: [] };
+
+const policySlice = createSlice({
+  name: 'policy',
+  initialState,
+  reducers: {
+    enactPolicy(state, action: PayloadAction<string>) {
+      state.enacted.push(action.payload);
+    }
+  }
+});
+
+export const { enactPolicy } = policySlice.actions;
+export const policyReducer = policySlice.reducer;

--- a/packages/game-core/tsconfig.json
+++ b/packages/game-core/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
## Summary
- set up `civicfire-engine` monorepo with `game-core` and `game-client` packages
- implement redux slices and simulation engine in game-core
- scaffold React + Vite client with canvas, HUD and policy menu components and placeholder assets

## Testing
- `npm test --workspace packages/game-core` *(fails: Cannot find module '@reduxjs/toolkit')*
- `npm test --workspace packages/game-client` *(fails: Cannot find module 'react', 'game-core', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688f4b4c48f0832aa0b76590a05d6aca