### PR TITLE
Implement basic simulation turn logic

### DIFF
--- a/packages/game-core/src/index.ts
+++ b/packages/game-core/src/index.ts
@@ -2,4 +2,5 @@ export * from './slices/combatSlice';
 export * from './slices/economySlice';
 export * from './slices/factionsSlice';
 export * from './slices/policySlice';
-export * from './simulation';
+export { SimulationEngine, produceResources, resolveCombat } from './simulation';
+export type { SimulationState } from './simulation';

--- a/packages/game-core/src/simulation.ts
+++ b/packages/game-core/src/simulation.ts
@@ -1,9 +1,67 @@
+export interface SimulationState {
+  /** Current turn counter */
+  turn: number;
+  /** Amount of credits owned by the player */
+  credits: number;
+  /** Simple combat score used to track victories */
+  combatScore: number;
+}
+
+export const INITIAL_STATE: SimulationState = {
+  turn: 0,
+  credits: 0,
+  combatScore: 0
+};
+
+/**
+ * Produce resources for the current turn. For now this simply grants a fixed
+ * number of credits but can be expanded to include more complex economic
+ * rules.
+ */
+export function produceResources(state: SimulationState, amount = 10): number {
+  state.credits += amount;
+  return amount;
+}
+
+/**
+ * Resolve combat for the turn. This placeholder implementation increments the
+ * combat score each turn to represent ongoing battles.
+ */
+export function resolveCombat(state: SimulationState, score = 1): number {
+  state.combatScore += score;
+  return score;
+}
+
 export class SimulationEngine {
+  private state: SimulationState = { ...INITIAL_STATE };
+  private elapsed = 0;
+  private readonly turnLength = 1000; // milliseconds per turn
+
   start() {
     console.log('Simulation started');
   }
 
-  update(_delta: number) {
-    // TODO: simulation logic
+  /**
+   * Advance the simulation by the given delta time in milliseconds. Whenever a
+   * full turn has elapsed we update the internal state to reflect resource
+   * production and combat resolution.
+   */
+  update(delta: number) {
+    this.elapsed += delta;
+
+    while (this.elapsed >= this.turnLength) {
+      this.elapsed -= this.turnLength;
+      this.state.turn += 1;
+
+      // Economy
+      produceResources(this.state);
+
+      // Combat
+      resolveCombat(this.state);
+    }
+  }
+
+  getState(): SimulationState {
+    return this.state;
   }
 }


### PR DESCRIPTION
## Summary
- add SimulationState and helpers for resource production and combat
- update SimulationEngine to advance turns and apply state changes
- export new simulation utilities through package entry point

## Testing
- `npm test --workspaces`


------
https://chatgpt.com/codex/tasks/task_e_68aea1a77df8832a805b1b12ab9c04e1