### PR TITLE
Add slice tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm install
+      - run: npm test -w game-core
+      - run: npm test -w game-client
+

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The repository uses npm workspaces and is organized into two packages:
 Run package scripts from the repository root with npm's workspace flag (`-w` or `--workspace`).
 
 ### Core library
-- `npm test -w game-core` – type-check the core library.
+- `npm test -w game-core` – compile the core library and run its unit tests.
 - `npm run build -w game-core` – compile TypeScript to `dist/`.
 
 ### Client
@@ -40,3 +40,6 @@ npm run build -w game-core
 ```
 
 The compiled files are output to `packages/game-core/dist/`.
+
+## Continuous Integration
+GitHub Actions runs `npm test -w game-core` and `npm test -w game-client` on every push and pull request to verify the core library and client build correctly.

--- a/packages/game-client/src/components/GameCanvas.tsx
+++ b/packages/game-client/src/components/GameCanvas.tsx
@@ -1,13 +1,12 @@
 import { useRef, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import type { RootState } from '../store';
+import { useAppDispatch, useAppSelector } from '../store';
 import { addScore, adjustCredits } from 'game-core';
 
 export default function GameCanvas() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const dispatch = useDispatch();
-  const score = useSelector((state: RootState) => state.combat.score);
-  const credits = useSelector((state: RootState) => state.economy.credits);
+  const dispatch = useAppDispatch();
+  const score = useAppSelector(state => state.combat.score);
+  const credits = useAppSelector(state => state.economy.credits);
 
   // draw units and terrain whenever relevant state changes
   useEffect(() => {

--- a/packages/game-client/src/components/HUD.tsx
+++ b/packages/game-client/src/components/HUD.tsx
@@ -1,9 +1,8 @@
-import { useSelector } from 'react-redux';
-import { RootState } from '../store';
+import { useAppSelector } from '../store';
 
 export default function HUD() {
-  const score = useSelector((state: RootState) => state.combat.score);
-  const credits = useSelector((state: RootState) => state.economy.credits);
+  const score = useAppSelector(state => state.combat.score);
+  const credits = useAppSelector(state => state.economy.credits);
 
   return (
     <div>

--- a/packages/game-client/src/components/PolicyMenu.tsx
+++ b/packages/game-client/src/components/PolicyMenu.tsx
@@ -1,10 +1,9 @@
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '../store';
 import { enactPolicy } from 'game-core';
-import { RootState } from '../store';
 
 export default function PolicyMenu() {
-  const dispatch = useDispatch();
-  const policies = useSelector((state: RootState) => state.policy.enacted);
+  const dispatch = useAppDispatch();
+  const policies = useAppSelector(state => state.policy.enacted);
 
   const handleEnact = () => {
     dispatch(enactPolicy('New Policy'));
@@ -14,7 +13,7 @@ export default function PolicyMenu() {
     <div>
       <button onClick={handleEnact}>Enact Policy</button>
       <ul>
-        {policies.map((p, i) => (
+        {policies.map((p: string, i: number) => (
           <li key={i}>{p}</li>
         ))}
       </ul>

--- a/packages/game-client/src/store.ts
+++ b/packages/game-client/src/store.ts
@@ -1,10 +1,22 @@
 import { configureStore } from '@reduxjs/toolkit';
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import {
   combatReducer,
   economyReducer,
   factionsReducer,
-  policyReducer
+  policyReducer,
+  type CombatState,
+  type EconomyState,
+  type FactionsState,
+  type PolicyState
 } from 'game-core';
+
+export interface RootState {
+  combat: CombatState;
+  economy: EconomyState;
+  factions: FactionsState;
+  policy: PolicyState;
+}
 
 export const store = configureStore({
   reducer: {
@@ -15,5 +27,7 @@ export const store = configureStore({
   }
 });
 
-export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
+
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/packages/game-core/package.json
+++ b/packages/game-core/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "tsc -p tsconfig.json --noEmit"
+    "test": "tsc -p tsconfig.json && node --test dist/**/*.test.js",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   }
 }

--- a/packages/game-core/src/node-test.d.ts
+++ b/packages/game-core/src/node-test.d.ts
@@ -1,0 +1,10 @@
+declare module 'node:test' {
+  export const describe: any;
+  export const it: any;
+}
+
+declare module 'node:assert/strict' {
+  const assert: any;
+  export default assert;
+}
+

--- a/packages/game-core/src/slices/combatSlice.test.ts
+++ b/packages/game-core/src/slices/combatSlice.test.ts
@@ -1,0 +1,11 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { combatReducer, addScore } from './combatSlice.js';
+
+describe('combatSlice', () => {
+  it('adds to the score', () => {
+    const state = combatReducer({ score: 0 }, addScore(5));
+    assert.strictEqual(state.score, 5);
+  });
+});
+

--- a/packages/game-core/src/slices/combatSlice.ts
+++ b/packages/game-core/src/slices/combatSlice.ts
@@ -1,6 +1,8 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import toolkit from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+const { createSlice } = toolkit as any;
 
-interface CombatState {
+export interface CombatState {
   score: number;
 }
 
@@ -10,7 +12,7 @@ const combatSlice = createSlice({
   name: 'combat',
   initialState,
   reducers: {
-    addScore(state, action: PayloadAction<number>) {
+    addScore(state: CombatState, action: PayloadAction<number>) {
       state.score += action.payload;
     }
   }

--- a/packages/game-core/src/slices/economySlice.test.ts
+++ b/packages/game-core/src/slices/economySlice.test.ts
@@ -1,0 +1,11 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { economyReducer, adjustCredits } from './economySlice.js';
+
+describe('economySlice', () => {
+  it('adjusts credits', () => {
+    const state = economyReducer({ credits: 0 }, adjustCredits(10));
+    assert.strictEqual(state.credits, 10);
+  });
+});
+

--- a/packages/game-core/src/slices/economySlice.ts
+++ b/packages/game-core/src/slices/economySlice.ts
@@ -1,6 +1,8 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import toolkit from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+const { createSlice } = toolkit as any;
 
-interface EconomyState {
+export interface EconomyState {
   credits: number;
 }
 
@@ -10,7 +12,7 @@ const economySlice = createSlice({
   name: 'economy',
   initialState,
   reducers: {
-    adjustCredits(state, action: PayloadAction<number>) {
+    adjustCredits(state: EconomyState, action: PayloadAction<number>) {
       state.credits += action.payload;
     }
   }

--- a/packages/game-core/src/slices/factionsSlice.test.ts
+++ b/packages/game-core/src/slices/factionsSlice.test.ts
@@ -1,0 +1,11 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { factionsReducer, setAlignment } from './factionsSlice.js';
+
+describe('factionsSlice', () => {
+  it('sets alignment', () => {
+    const state = factionsReducer({ alignment: 'neutral' }, setAlignment('ally'));
+    assert.strictEqual(state.alignment, 'ally');
+  });
+});
+

--- a/packages/game-core/src/slices/factionsSlice.ts
+++ b/packages/game-core/src/slices/factionsSlice.ts
@@ -1,6 +1,8 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import toolkit from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+const { createSlice } = toolkit as any;
 
-interface FactionsState {
+export interface FactionsState {
   alignment: string;
 }
 
@@ -10,7 +12,7 @@ const factionsSlice = createSlice({
   name: 'factions',
   initialState,
   reducers: {
-    setAlignment(state, action: PayloadAction<string>) {
+    setAlignment(state: FactionsState, action: PayloadAction<string>) {
       state.alignment = action.payload;
     }
   }

--- a/packages/game-core/src/slices/policySlice.test.ts
+++ b/packages/game-core/src/slices/policySlice.test.ts
@@ -1,0 +1,11 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { policyReducer, enactPolicy } from './policySlice.js';
+
+describe('policySlice', () => {
+  it('adds enacted policies', () => {
+    const state = policyReducer({ enacted: [] }, enactPolicy('law'));
+    assert.ok(state.enacted.includes('law'));
+  });
+});
+

--- a/packages/game-core/src/slices/policySlice.ts
+++ b/packages/game-core/src/slices/policySlice.ts
@@ -1,6 +1,8 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import toolkit from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+const { createSlice } = toolkit as any;
 
-interface PolicyState {
+export interface PolicyState {
   enacted: string[];
 }
 
@@ -10,7 +12,7 @@ const policySlice = createSlice({
   name: 'policy',
   initialState,
   reducers: {
-    enactPolicy(state, action: PayloadAction<string>) {
+    enactPolicy(state: PolicyState, action: PayloadAction<string>) {
       state.enacted.push(action.payload);
     }
   }


### PR DESCRIPTION
## Summary
- add Node-based tests for combat, economy, factions and policy slices
- configure core package test script and typed hooks for client store
- set up CI workflow to run game-core and game-client tests
- document testing and CI process in README

## Testing
- `npm test -w game-core`
- `npm test -w game-client`


------
https://chatgpt.com/codex/tasks/task_e_68aea3bab8ec832a933d1edf7dc11fc3