### PR TITLE
Add architecture and game mechanics documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ The repository uses npm workspaces and is organized into two packages:
 - **packages/game-core** – simulation engine and Redux slices for combat, economy, factions and policy.
 - **packages/game-client** – Vite-powered React front end that consumes the core library.
 
+## Contributor Documentation
+- [Architecture Overview](docs/architecture-overview.md)
+- [Game Mechanics](docs/game-mechanics.md)
+
 ## Development Scripts
 Run package scripts from the repository root with npm's workspace flag (`-w` or `--workspace`).
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1,0 +1,17 @@
+# Architecture Overview
+
+Spreadfire is organized as a TypeScript monorepo with two primary packages managed through npm workspaces.
+
+## Packages
+
+- **game-core**: Contains the simulation engine and Redux slices that model combat, economy, factions, and policy. It exposes the `SimulationEngine` class along with helper functions for turn advancement and resource management.
+- **game-client**: A React front end built with Vite. The client consumes `game-core` and renders game state through a Redux store.
+
+## Data Flow
+
+1. `SimulationEngine` advances turns and updates the core simulation state.
+2. Redux slices expose actions and reducers for combat, economy, factions, and policy.
+3. The client subscribes to these slices to display the evolving state and dispatch player actions.
+
+This modular design allows the core logic to be tested independently from the user interface while enabling the client to reuse the simulation library.
+

--- a/docs/game-mechanics.md
+++ b/docs/game-mechanics.md
@@ -1,0 +1,20 @@
+# Game Mechanics
+
+The Spreadfire simulation is a turn-based strategy model that tracks economic growth and combat outcomes.
+
+## Turn Structure
+
+Each turn represents a fixed amount of simulated time. During a turn the engine:
+
+1. Produces resources, adding a set amount of credits to the player's economy.
+2. Resolves combat, incrementing a combat score to represent engagements.
+
+## Systems
+
+- **Economy**: Managed through the `economySlice`; it governs credit production and future economic rules.
+- **Combat**: Handled by the `combatSlice`; future versions will expand on unit types and battle resolution.
+- **Factions**: The `factionsSlice` tracks relationships and can be extended for diplomacy or alliances.
+- **Policy**: Controlled by the `policySlice`, allowing rule changes that modify other systems.
+
+These mechanics provide a foundation that can evolve into more complex strategic gameplay.
+


### PR DESCRIPTION
## Summary
- add docs for repository architecture
- document core game mechanics for the simulation
- link new docs from README for contributor onboarding

## Testing
- `npm test -w game-core`
- `npm test -w game-client`


------
https://chatgpt.com/codex/tasks/task_e_68aea5d1c2e8832aa1eca5847cda35d3